### PR TITLE
Use codeblocks and adjust microspacing in scoreboard

### DIFF
--- a/HTWDiscordBot/Services/HTW/HtmlParserService.cs
+++ b/HTWDiscordBot/Services/HTW/HtmlParserService.cs
@@ -16,15 +16,17 @@ namespace HTWDiscordBot.Services
         public string ParseScoreBoard(string html)
         {
             HtmlDocument document = LoadHtml(html);
-            string scoreboard = "**" + String.Format("{0,-6} {1,-9} {2,-40}", "Platz", "Punktzahl", "Benutzername").Replace(" ", "᲼") + "**";
+            string codeblock = $"```ansi\n\u001b[1;32mPlatz  Punktzahl Benutzername\u001b[0m\n";
 
             foreach (HtmlNode player in document.DocumentNode.SelectSingleNode(scoreboardPath).Descendants("tr").Take(50))
             {
                 List<HtmlNode> playerData = player.Descendants("td").ToList();
-
-                scoreboard += String.Format("\n{0,-5} {1,-9} {2,-40}", playerData[0].InnerText, playerData[2].InnerText, playerData[1].InnerText).Replace(" ", "᲼");
+                
+                codeblock += $"{playerData[0].InnerText.PadRight(2)}\t {playerData[2].InnerText}\t  {playerData[1].InnerText}\n";
             }
-            return scoreboard;
+
+            codeblock += "```";
+            return codeblock;
         }
 
         //Versucht einen Username aus der HTML-Datei zu parsen


### PR DESCRIPTION
Das aktuelle Format vom Scoreboard ist finde ich etwas unschön. Die verschiedenen Einträge haben keinen konstanten Abstand und auf (älteren) Mobile Clients sind die unsichtbaren Unicode Zeichen sichtbar.

Mit diesem Pull Request wird das Scoreboard mit multiline Codeblöcken (beginnend und endend mit ```) umgesetzt. Der Vorteil hierbei ist, dass jedes Zeichen durch die Monospace Font gleich groß ist und vor allem Abstände/Tabs bewahrt werden. Der PR verändert die Formattierung also von Unicode Zeichen zu Tabs und Leerzeichen. Dieses Microspacing ist zwar vom Code her immer noch nicht wirklich schön, der Output ist dann aber wenigstens cleaner (finde ich zumindest). 

Weil in Codeblöcken keine klassische Markdown Formattierung unterstützt wird und ich den Header deswegen nicht fett drucken konnte, hab ich die Kopfzeile stattdessen mithilfe von ANSI farblich gemacht (siehe [hier](https://gist.github.com/kkrypt0nn/a02506f3712ff2d1c8ca7c9e0aed7c06)).


Vorher: 
![grafik](https://user-images.githubusercontent.com/68434250/235378511-19967251-4f8e-4de0-8227-07fab2862d22.png)

Nachher:
![grafik](https://user-images.githubusercontent.com/68434250/235378500-fec05083-ebb3-4986-840a-bc9936ab4d87.png)


Hoffe das passt vom PR so ^^ Ist zwar jetzt wahrscheinlich eine eher subjektive Verbesserung aber ich dachte ich versuch mal was zu fixen was mich gestört hat. Danke noch mal für den Bot, ist wirklich toll was du da alles für arbeit reinsteckst :))